### PR TITLE
[feat] タスクデータの追加削除機能の実装

### DIFF
--- a/frontend/src/api/firebase.ts
+++ b/frontend/src/api/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -14,4 +15,5 @@ const firebaseConfig = {
 initializeApp(firebaseConfig);
 
 const auth = getAuth();
-export { firebaseConfig, auth };
+const firebaseFirestore = getFirestore();
+export { firebaseConfig, auth, firebaseFirestore };

--- a/frontend/src/components/top/AddTaskForm/index.tsx
+++ b/frontend/src/components/top/AddTaskForm/index.tsx
@@ -1,4 +1,5 @@
-import { useState, VFC } from "react";
+import { useState } from "react";
+import type { MouseEventHandler, ChangeEventHandler, VFC } from "react";
 import { TextField } from "@material-ui/core";
 import {
   KeyboardDatePicker,
@@ -8,13 +9,16 @@ import DateFnsUtils from "@date-io/date-fns/";
 import { BaseButton } from "../../utils/BaseButton";
 import styles from "./index.module.css";
 
-const AddTaskForm: VFC = () => {
+interface Props {
+  input: string;
+  onChange: ChangeEventHandler;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+const AddTaskForm: VFC<Props> = ({ input, onChange, onClick }: Props) => {
   const [date, setDate] = useState<Date | null>(new Date());
   const handleChangeDate = (newDate: Date | null) => {
     setDate(newDate);
-  };
-  const handleClickTaskAddButton = (): void => {
-    console.log("押した");
   };
   return (
     <>
@@ -27,7 +31,9 @@ const AddTaskForm: VFC = () => {
               hiddenLabel
               placeholder="タスクを入力してください"
               variant="outlined"
-              style={{marginRight: "30px"}}
+              style={{ marginRight: "30px" }}
+              onChange={onChange}
+              value={input}
             />
           </form>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -44,7 +50,7 @@ const AddTaskForm: VFC = () => {
             className={styles.addButton}
             color="#24C075"
             text="追加"
-            onClick={handleClickTaskAddButton}
+            onClick={onClick}
           />
         </div>
       </div>

--- a/frontend/src/components/top/TaskPanel/index.tsx
+++ b/frontend/src/components/top/TaskPanel/index.tsx
@@ -1,18 +1,18 @@
 import clsx from "clsx";
-import type { MouseEventHandler, VFC } from "react";
+import type { VFC } from "react";
 import { List, ListItem } from "@material-ui/core";
 import styles from "./index.module.css";
 import { BaseButton } from "../../utils/BaseButton";
 
 interface Props {
   title: string;
-  taskData: string[];
+  taskData: (string | undefined)[];
   buttonLabel1: string;
   buttonLabel2?: string;
   buttonColor1: string;
   buttonColor2?: string;
   className?: string;
-  onClick1: MouseEventHandler<HTMLButtonElement>;
+  onClick1: (idx: number) => void;
   onClick2: (idx: number) => void;
 }
 
@@ -39,7 +39,7 @@ const TaskPanel: VFC<Props> = ({
                 <div className={styles.completeButton}>
                   <BaseButton
                     color={buttonColor1}
-                    onClick={onClick1}
+                    onClick={() => onClick1(index)}
                     text={buttonLabel1}
                   />
                 </div>

--- a/frontend/src/components/top/TaskPanel/index.tsx
+++ b/frontend/src/components/top/TaskPanel/index.tsx
@@ -4,21 +4,16 @@ import { List, ListItem } from "@material-ui/core";
 import styles from "./index.module.css";
 import { BaseButton } from "../../utils/BaseButton";
 
-interface Task {
-  id: number;
-  content: string;
-}
-
 interface Props {
   title: string;
-  taskData: Task[];
+  taskData: string[];
   buttonLabel1: string;
   buttonLabel2?: string;
   buttonColor1: string;
   buttonColor2?: string;
   className?: string;
   onClick1: MouseEventHandler<HTMLButtonElement>;
-  onClick2: MouseEventHandler<HTMLButtonElement>;
+  onClick2: (idx: number) => void;
 }
 
 const TaskPanel: VFC<Props> = ({
@@ -28,38 +23,35 @@ const TaskPanel: VFC<Props> = ({
   buttonLabel2 = "削除",
   buttonColor1,
   buttonColor2 = "#E73152",
-  className="",
+  className = "",
   onClick1,
   onClick2,
 }: Props) => {
-  const TaskListItem = (datas: Task[]): JSX.Element[] => {
-    return datas.map((data) => {
-      return (
-        <ListItem style={{ paddingLeft: "0px" }}>
-          <p className={styles.listItemText}>{data.content}</p>
-          <div className={styles.taskButtonWrapper}>
-            <div className={styles.completeButton}>
-              <BaseButton
-                color={buttonColor1}
-                onClick={onClick1}
-                text={buttonLabel1}
-              />
-            </div>
-            <BaseButton
-              color={buttonColor2}
-              onClick={onClick2}
-              text={buttonLabel2}
-            />
-          </div>
-        </ListItem>
-      );
-    });
-  };
   return (
     <>
-      <div className={clsx(styles.panel,className)}>
+      <div className={clsx(styles.panel, className)}>
         <p className={styles.panelTitle}>{title}</p>
-        <List style={{ fontSize: "20px" }}>{TaskListItem(taskData)}</List>
+        <List style={{ fontSize: "20px" }}>
+          {taskData.map((task, index) => (
+            <ListItem style={{ paddingLeft: "0px" }}>
+              <p className={styles.listItemText}>{task}</p>
+              <div className={styles.taskButtonWrapper}>
+                <div className={styles.completeButton}>
+                  <BaseButton
+                    color={buttonColor1}
+                    onClick={onClick1}
+                    text={buttonLabel1}
+                  />
+                </div>
+                <BaseButton
+                  color={buttonColor2}
+                  onClick={() => onClick2(index)}
+                  text={buttonLabel2}
+                />
+              </div>
+            </ListItem>
+          ))}
+        </List>
       </div>
     </>
   );

--- a/frontend/src/components/top/TaskTabs/index.tsx
+++ b/frontend/src/components/top/TaskTabs/index.tsx
@@ -37,7 +37,13 @@ const theme = createTheme({
   },
 });
 
-const TaskTabs: VFC = () => {
+interface Props {
+  finishedList: (string | undefined)[];
+  onClick5: (idx: number) => void;
+  onClick6: (idx: number) => void;
+}
+
+const TaskTabs: VFC<Props> = ({ finishedList, onClick5, onClick6 }: Props) => {
   const dummyData = ["あいうえお", "かきくけこ", "さしすせそ"];
   const classes = useStyles();
   const [value, setValue] = useState(0);
@@ -47,9 +53,6 @@ const TaskTabs: VFC = () => {
   };
   const handleOnClickToTodayButton = (): void => {
     console.log("今日へ押した");
-  };
-  const handleOnClickUndoButton = (): void => {
-    console.log("元に戻す押した");
   };
   const handleOnClickDeleteButton = (): void => {
     console.log("削除押した");
@@ -140,11 +143,11 @@ const TaskTabs: VFC = () => {
           <TabPanel value={value} index={2}>
             <TaskPanel
               title="完了済みのたすく！"
-              taskData={dummyData}
+              taskData={finishedList}
               buttonLabel1="元に戻す"
               buttonColor1="#69A41F"
-              onClick1={handleOnClickUndoButton}
-              onClick2={handleOnClickDeleteButton}
+              onClick1={onClick5}
+              onClick2={onClick6}
             />
           </TabPanel>
         </Paper>

--- a/frontend/src/components/top/TaskTabs/index.tsx
+++ b/frontend/src/components/top/TaskTabs/index.tsx
@@ -38,11 +38,7 @@ const theme = createTheme({
 });
 
 const TaskTabs: VFC = () => {
-  const dummyData = [
-    { id: 1, content: "あいうえお" },
-    { id: 2, content: "かきくけこ" },
-    { id: 3, content: "さしすせそ" },
-  ];
+  const dummyData = ["あいうえお", "かきくけこ", "さしすせそ"];
   const classes = useStyles();
   const [value, setValue] = useState(0);
 
@@ -76,7 +72,7 @@ const TaskTabs: VFC = () => {
             TabIndicatorProps={{ style: { background: "#8EF3AA" } }}
           >
             <Tab
-              style={{backgroundColor:"#DAF8E7"}}
+              style={{ backgroundColor: "#DAF8E7" }}
               label={
                 <div>
                   <CheckBoxOutlineBlankOutlinedIcon
@@ -91,7 +87,7 @@ const TaskTabs: VFC = () => {
               }
             />
             <Tab
-              style={{backgroundColor:"#DAF8E7"}}
+              style={{ backgroundColor: "#DAF8E7" }}
               label={
                 <div>
                   <ListAltOutlinedIcon
@@ -106,7 +102,7 @@ const TaskTabs: VFC = () => {
               }
             />
             <Tab
-              style={{backgroundColor:"#DAF8E7"}}
+              style={{ backgroundColor: "#DAF8E7" }}
               label={
                 <div>
                   <CheckBoxOutlinedIcon

--- a/frontend/src/pages/top/index.tsx
+++ b/frontend/src/pages/top/index.tsx
@@ -12,22 +12,54 @@ import styles from "./index.module.css";
 
 const Top: VFC = () => {
   const [input, setInput] = useState("");
-  const [todoList, setTodoList] = useState([] as string[]);
+  const [todoList, setTodoList] = useState([] as (string | undefined)[]);
+  const [finishedTodoList, setFinishedTodoList] = useState(
+    [] as (string | undefined)[]
+  );
+
+  // タスク入力フォームのハンドラ
   const handleChangeTaskInputForm = (
     e: ChangeEvent<HTMLInputElement>
   ): void => {
     setInput(e.target.value);
   };
+
+  // タスク追加ボタンハンドラ
   const handleClickTaskAddButton = (): void => {
-    setTodoList([...todoList, input]);
-    setInput("");
+    if (!!input) {
+      setTodoList([...todoList, input]);
+      setInput("");
+    } else {
+      alert("タスクを入力してください");
+    }
   };
 
-  const handleOnClickCompleteButton = (): void => {
-    console.log("完了押した");
-  };
+  // 本日タスクの削除ボタンハンドラ
   const handleOnClickDeleteButton = (index: number): void => {
     setTodoList(todoList.filter((_, idx) => idx !== index));
+  };
+
+  // 本日タスクの完了ボタンハンドラ
+  const handleOnClickCompleteButton = (index: number): void => {
+    setTodoList(todoList.filter((_, idx) => idx !== index));
+    setFinishedTodoList([
+      ...finishedTodoList,
+      todoList.find((_, idx) => idx === index),
+    ]);
+  };
+
+  // 完了済みタスクボタンハンドラ
+  const handleOnClickFinishedTaskDeleteButton = (index: number) => {
+    setFinishedTodoList(finishedTodoList.filter((_, idx) => idx !== index));
+  };
+
+  // 未完了ボタンハンドラ
+  const handleOnClickNotCompleteButton = (index: number) => {
+    setFinishedTodoList(finishedTodoList.filter((_, idx) => idx !== index));
+    setTodoList([
+      ...todoList,
+      finishedTodoList.find((_, idx) => idx === index),
+    ]);
   };
 
   return (
@@ -48,7 +80,11 @@ const Top: VFC = () => {
         onClick1={handleOnClickCompleteButton}
         onClick2={handleOnClickDeleteButton}
       />
-      <TaskTabs />
+      <TaskTabs
+        finishedList={finishedTodoList}
+        onClick5={handleOnClickNotCompleteButton}
+        onClick6={handleOnClickFinishedTaskDeleteButton}
+      />
       <Footer />
     </>
   );

--- a/frontend/src/pages/top/index.tsx
+++ b/frontend/src/pages/top/index.tsx
@@ -1,32 +1,47 @@
-import type { VFC } from "react";
+import { useState } from "react";
 import { AddTaskForm } from "../../components/top/AddTaskForm";
 import { Calendar } from "../../components/top/Calendar";
 import { Navber } from "../../components/top/Navber";
 import { TaskPanel } from "../../components/top/TaskPanel";
 import { TaskTabs } from "../../components/top/TaskTabs";
 import { Footer } from "../../components/utils/Footer";
+
+import type { ChangeEvent, VFC } from "react";
+
 import styles from "./index.module.css";
 
 const Top: VFC = () => {
-  const dummyData = [
-    { id: 1, content: "あいうえお" },
-    { id: 2, content: "かきくけこ" },
-    { id: 3, content: "さしすせそ" },
-  ];
+  const [input, setInput] = useState("");
+  const [todoList, setTodoList] = useState([] as string[]);
+  const handleChangeTaskInputForm = (
+    e: ChangeEvent<HTMLInputElement>
+  ): void => {
+    setInput(e.target.value);
+  };
+  const handleClickTaskAddButton = (): void => {
+    setTodoList([...todoList, input]);
+    setInput("");
+  };
+
   const handleOnClickCompleteButton = (): void => {
     console.log("完了押した");
   };
-  const handleOnClickDeleteButton = (): void => {
-    console.log("削除押した");
+  const handleOnClickDeleteButton = (index: number): void => {
+    setTodoList(todoList.filter((_, idx) => idx !== index));
   };
+
   return (
     <>
       <Navber />
       <Calendar />
-      <AddTaskForm />
+      <AddTaskForm
+        input={input}
+        onChange={handleChangeTaskInputForm}
+        onClick={handleClickTaskAddButton}
+      />
       <TaskPanel
         title="本日のたすく！"
-        taskData={dummyData}
+        taskData={todoList}
         buttonLabel1="完了"
         buttonColor1="#24C075"
         className={styles.todaysTaskPanel}

--- a/frontend/src/pages/top/index.tsx
+++ b/frontend/src/pages/top/index.tsx
@@ -23,6 +23,7 @@ const Top: VFC = () => {
   const [isChangedTodo, setIsChangedTodo] = useState(false);
   const [isChangedFinishedTodo, setIsChangedFiished] = useState(false);
 
+  // Firebaseからのデータの取得
   useEffect(() => {
     (async () => {
       console.log(firebaseFirestore);
@@ -32,26 +33,28 @@ const Top: VFC = () => {
       setTodoList(responseTodo.data()?.tasks);
       setIsLoading(false);
     })();
-  }, [firebaseFirestore]);
+  }, [isLoading]);
 
+  // Todoに変更が加わった時
   useEffect(() => {
     if (isChangedTodo) {
       (async () => {
         setIsLoading(true);
-        const docRef = await updateDoc(
+        updateDoc(
           doc(firebaseFirestore, "todoList/todo"),
           { tasks: todoList }
         );
         setIsLoading(false);
       })();
     }
-  }, [todoList, isChangedTodo, firebaseFirestore]);
+  }, [todoList, isChangedTodo]);
 
+  // 完了済みに変更が加わった時
   useEffect(() => {
     if (isChangedFinishedTodo) {
       (async () => {
         setIsLoading(true);
-        const docRef = await updateDoc(
+        updateDoc(
           doc(firebaseFirestore, "todoList/finishedTodo"),
           { tasks: finishedTodoList }
         );
@@ -59,7 +62,7 @@ const Top: VFC = () => {
       })();
     }
     setIsChangedFiished(false);
-  }, [firebaseFirestore, finishedTodoList, isChangedFinishedTodo]);
+  }, [finishedTodoList, isChangedFinishedTodo]);
   // タスク入力フォームのハンドラ
   const handleChangeTaskInputForm = (
     e: ChangeEvent<HTMLInputElement>


### PR DESCRIPTION
# やったこと
- [x] 動的にデータの追加、削除が行うことができる
- [x] 完了未完了のデータ移動ができる
- [x] Firestoreと連携してデータを維持できる

resolved #43 

# 直すべき場所
- [ ] タスク入力時useStateが毎回走ってレンダリングが毎回起こるため他のHooks（思いつくのはuseRef)を使ってレンダリングが起こらないようにする